### PR TITLE
Enhanced CSS styles for the wiki (QA-8866)

### DIFF
--- a/src/main/resources/css/wiki.css
+++ b/src/main/resources/css/wiki.css
@@ -222,3 +222,28 @@ display:block
 	margin-right:8px;
 	padding-left:20px;
 }
+
+.wiki h2 {   
+    padding: 12px 0 8px 0;
+    border-bottom: 1px solid #aaa;
+}
+
+.wiki h3 {
+    font-size: 20px !important;
+    font-weight: 500;
+    padding: 12px 0 0 0;
+}
+.wiki h4 {
+    font-size: 16px;
+    padding: 15px 0 0 0;
+    text-decoration:underline;
+}
+    
+.wiki p {
+    margin: 0 0 8px;
+    color: #777;
+}
+
+.wiki strong {
+    color: #2d2d2d;
+}


### PR DESCRIPTION
Current CSS styles doesn't really provide much difference between H1, H2, H3, H4. All Wiki entries look very confusion because the structure isn't straightforward to understand.
This small enhancement helps improve things.
